### PR TITLE
Summary: updated tag listing to show workspace name

### DIFF
--- a/toggl-cmder/__main__.py
+++ b/toggl-cmder/__main__.py
@@ -74,6 +74,9 @@ if __name__ == "__main__":
 
     user_data = instance.download_user_data()
 
+    for tag in user_data.tags:
+        tag.workspace = user_data.get_workspace_from_id(tag.workspace_id)
+
     if args.token_reset:
         token = instance.reset_user_token()
         instance = Interface(api_token=token,

--- a/toggl-cmder/toggl/tag.py
+++ b/toggl-cmder/toggl/tag.py
@@ -6,6 +6,8 @@ class Tag(object):
         self.__name = kwargs.get('name')
         self.__workspace_id = kwargs.get('workspace_id')
 
+        self.__workspace = None
+
     @property
     def name(self):
         return self.__name
@@ -17,6 +19,14 @@ class Tag(object):
     @property
     def workspace_id(self):
         return self.__workspace_id
+
+    @property
+    def workspace(self):
+        return self.__workspace
+
+    @workspace.setter
+    def workspace(self, workspace):
+        self.__workspace = workspace
 
     @staticmethod
     def api_url():
@@ -30,6 +40,6 @@ class Tag(object):
     def __str__(self):
         return "{},{},{}".format(
             self.__name,
-            self.__workspace_id,
+            self.__workspace.name,
             self.__id
         )


### PR DESCRIPTION
Details:
    >   issue #2
        >   __main__ now updates tags after downloading
            completed user data
        >   tag now uses workspace ref to get name rather
            than showing workspace ID