### PR TITLE
Summary: fixed incorrect endpoint URL for starting timers

### DIFF
--- a/toggl-cmder/toggl/interface.py
+++ b/toggl-cmder/toggl/interface.py
@@ -106,7 +106,7 @@ class Interface(object):
 
     def start_time_entry(self, time_entry):
         data = json.dumps(time_entry, cls=time_entry_encoder.TimeEntryEncoder)
-        result = requests.post(time_entry.api_url(),
+        result = requests.post(time_entry.api_start_entry_url(),
                                data=data,
                                auth=self.__auth)
         result.raise_for_status()


### PR DESCRIPTION
Details:
    >   issue #9
        >   endpoint for starting a new timer was incorrect