### PR TITLE
Summary: added resume timer functionality

### DIFF
--- a/toggl-cmder/__main__.py
+++ b/toggl-cmder/__main__.py
@@ -88,6 +88,8 @@ if __name__ == "__main__":
         for time_entry in user_data.time_entries:
             time_entry.project = user_data.get_project_from_id(time_entry.project_id)
             time_entry.workspace = user_data.get_workspace_from_id(time_entry.workspace_id)
+            for tag in time_entry.tags:
+                time_entry.add_tag_ref(user_data.find_user_tag(tag))
 
     if args.token_reset:
         token = instance.reset_user_token()
@@ -116,6 +118,11 @@ if __name__ == "__main__":
                 headers=["description", "project", "workspace", "duration", "tags"],
                 tablefmt="grid"
             )))
+
+    if args.resume_latest_timer:
+        time_entry = user_data.time_entries[-1]
+        if time_entry is not None:
+            instance.start_time_entry(time_entry)
 
     if args.stop_timer:
         logger.info("searching for current timer")

--- a/toggl-cmder/toggl/arguments.py
+++ b/toggl-cmder/toggl/arguments.py
@@ -48,6 +48,11 @@ class Arguments(object):
             help='Stop the current timer.')
 
         argument_parser.add_argument(
+            '--resume-latest-timer',
+            action='store_true',
+            help='Resume the latest timer.')
+
+        argument_parser.add_argument(
             '--current',
             help="Get current timer.",
             action='store_true')

--- a/toggl-cmder/toggl/encoders/time_entry_encoder.py
+++ b/toggl-cmder/toggl/encoders/time_entry_encoder.py
@@ -5,17 +5,12 @@ from toggl import time_entry
 class TimeEntryEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, time_entry.TimeEntry):
-            if o.stop_time is not None:
-                return { 'time_entry' : {
-                    '': ''
-                }}
-            else:
-                return { 'time_entry' :
-                         {
-                             'pid': o.project_id,
-                             'description': o.description,
-                             'start': o.start_time.isoformat(),
-                             'tags': [tag.name for tag in o.tags],
-                             'created_with': 'toggl_cmder'
-                         }}
+            return { 'time_entry' :
+                     {
+                         'pid': o.project_id,
+                         'description': o.description,
+                         'start': o.start_time.isoformat(),
+                         'tags': [tag.name for tag in o.tag_refs],
+                         'created_with': 'toggl_cmder'
+                     }}
         return super(TimeEntryEncoder, self).default(o)

--- a/toggl-cmder/toggl/interface.py
+++ b/toggl-cmder/toggl/interface.py
@@ -106,9 +106,11 @@ class Interface(object):
 
     def start_time_entry(self, time_entry):
         data = json.dumps(time_entry, cls=time_entry_encoder.TimeEntryEncoder)
+        self.__logger.debug("request.json: {}".format(data))
         result = requests.post(time_entry.api_start_entry_url(),
                                data=data,
                                auth=self.__auth)
+        self.__logger.debug("reply.text: {}".format(result.text))
         result.raise_for_status()
 
     def stop_time_entry(self, time_entry):

--- a/toggl-cmder/toggl/time_entry.py
+++ b/toggl-cmder/toggl/time_entry.py
@@ -27,6 +27,7 @@ class TimeEntry(object):
         except TypeError:
             self.__stop_time = None
 
+        self.__tag_refs = []
         self.__tags = kwargs.get('tags', [])
 
     @staticmethod
@@ -103,6 +104,13 @@ class TimeEntry(object):
     @property
     def tags(self):
         return self.__tags
+
+    @property
+    def tag_refs(self):
+        return self.__tag_refs
+
+    def add_tag_ref(self, ref):
+        self.__tag_refs.append(ref)
 
     def __str__(self):
         return "{},{},{},{},{}".format(


### PR DESCRIPTION
Details:
    >   issue #12
        >   added argument to allow resuming the most recent timer
        >   fixed an issue with encoding time entries when the
            time entry has a stop time.
        >   time entries are now updated with the relevant tag objects